### PR TITLE
[CW-28266] fix: return s32 to support TRX, DOT

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coolwallet/core",
-  "version": "2.0.7-beta.0",
+  "version": "2.0.8-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@coolwallet/core",
-      "version": "2.0.7-beta.0",
+      "version": "2.0.8-beta.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/elliptic": "^6.4.14",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coolwallet/core",
-  "version": "2.0.7-beta.0",
+  "version": "2.0.8-beta.0",
   "description": "Core library for other CoolWallet SDKs.",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/core/src/crypto/signature.ts
+++ b/packages/core/src/crypto/signature.ts
@@ -39,7 +39,7 @@ export const convertToDER = (sig: { r: string; s: string }): Buffer => {
   return derSignature;
 };
 
-export const getCanonicalSignature = (signature: { s?: any; r?: any, s32?: any }) => {
+export const getCanonicalSignature = (signature: { s: string; r: string}) => {
   const modulusString = 'FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141';
   const modulus = new BN(modulusString, 16);
   const s = new BN(signature.s, 16);

--- a/packages/core/src/transaction/util.ts
+++ b/packages/core/src/transaction/util.ts
@@ -7,9 +7,9 @@ import { SignatureType } from './type';
  *
  * @param {String} signature
  * @param {String} signatureType
- * @returns {{r:string, s:string} | Buffer } Buffer or DER signature
+ * @returns {{r:string, s:string, s32: string} | Buffer } Buffer or DER signature
  */
-export const formatSignature = (signature: string, signatureType: SignatureType): { r: string; s: string } | Buffer => {
+export const formatSignature = (signature: string, signatureType: SignatureType): { r: string; s: string; s32: string } | Buffer => {
   const iv = Buffer.alloc(16);
   iv.fill(0);
   const sigBuff = Buffer.from(signature, 'hex');
@@ -37,13 +37,13 @@ export const formatSignature = (signature: string, signatureType: SignatureType)
  * @param {String} encryptedSignature
  * @param {String} signatureKey
  * @param {SignatureType} signatureType
- * @return {{r:string, s:string} | Buffer } Buffer or DER signature
+ * @return {{r:string, s:string, s32: string} | Buffer } Buffer or DER signature
  */
 export const decryptSignatureFromSE = (
   encryptedSignature: string,
   signatureKey: string,
   signatureType: SignatureType
-): { r: string; s: string; s32?: string } | Buffer => {
+): { r: string; s: string; s32: string } | Buffer => {
   const iv = Buffer.alloc(16);
   iv.fill(0);
   const sigBuff = aes256CbcDecrypt(iv, Buffer.from(signatureKey, 'hex'), encryptedSignature);


### PR DESCRIPTION
## Overview

This PR fixes the `s32` field to be a required return value in the core signature utilities, ensuring TRX and DOT coin packages can reliably access it during transaction signing.

## Key Changes

- Made `s32` a required (non-optional) field in the return types of `formatSignature` and `decryptSignatureFromSE` in `packages/core/src/transaction/util.ts`, replacing the previous `s32?` optional signature.
- Cleaned up `getCanonicalSignature` parameter type in `packages/core/src/crypto/signature.ts`, removing the loose `any`-typed `s32` parameter and tightening the signature to `{ s: string; r: string }`.
- Bumped `@coolwallet/core` version from `2.0.7-beta.0` to `2.0.8-beta.0`.

## Verification

- CI passes (lint / type check / build).

## Related

- Task: https://app.clickup.com/t/CW-28266
 
 
 
 **PR Summary by Typo**
------------

#### Overview
This PR addresses an issue where the `s32` component of a signature was not consistently returned, which is necessary for supporting TRX and DOT transactions. The changes update signature formatting and decryption functions to ensure `s32` is always included in the returned signature object.

#### Key Changes
- Updated the package version from `2.0.7-beta.0` to `2.0.8-beta.0`.
- Modified `formatSignature` and `decryptSignatureFromSE` functions to explicitly include `s32` as a required string in their return types.
- Refined the input type for `getCanonicalSignature` to only expect `r` and `s` strings, removing the optional `s32` from its parameter.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| Rework      | 8 (100.0%)    |
| Total Changes | 8           | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>