### PR TITLE
[CW-28266] fix: use s32 instead of s for signature in coin-dot and coin-trx

### DIFF
--- a/.github/workflows/test-and-generate-report.yml
+++ b/.github/workflows/test-and-generate-report.yml
@@ -68,6 +68,21 @@ jobs:
     - name: Run Docker container
       run: docker run -d --name coolwallet-jcvm-jre-http -p 9527:9527 ${{ env.REGISTRY }}/${{ secrets.DEV_CP_GCP_PROJECT_ID }}/coolwallet/jcvm
 
+    - name: Wait for JCVM to be ready
+      run: |
+        echo "Waiting for JCVM on port 9527..."
+        for i in $(seq 1 30); do
+          if nc -z -w2 localhost 9527 2>/dev/null; then
+            echo "JCVM is ready (attempt $i)"
+            exit 0
+          fi
+          echo "Attempt $i/30 - not ready yet, waiting 2s..."
+          sleep 2
+        done
+        echo "JCVM failed to start after 60 seconds"
+        docker logs coolwallet-jcvm-jre-http
+        exit 1
+
     - name: Dump node environment
       working-directory: sdk
       run: 'echo "node: $(node -v) npm: $(npm -v)"'

--- a/packages/coin-dot/package-lock.json
+++ b/packages/coin-dot/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.1.0-beta.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@coolwallet/core": "^2.0.0",
+        "@coolwallet/core": "^2.0.8-beta.0",
         "@polkadot/keyring": "^6.0.5",
         "@types/node": "^14.0.13",
         "blake2b": "^2.1.3",
@@ -1470,9 +1470,9 @@
       }
     },
     "node_modules/@coolwallet/core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@coolwallet/core/-/core-2.0.0.tgz",
-      "integrity": "sha512-lXtRFawJyV/0BtXlWVgm0H/B/8tvVtHUgHCQCwhPDoa5uCbg9gW8R3JKLepq5NnGXd1IPu8xqMt/hzxh2t+6Ww==",
+      "version": "2.0.8-beta.0",
+      "resolved": "https://registry.npmjs.org/@coolwallet/core/-/core-2.0.8-beta.0.tgz",
+      "integrity": "sha512-vVaQUxitah6ehPb3a9TSv2u2H5Ehc26xprPwbuRYavdQ2jaVZ8fsaHWcmuEe9VCKveKzDg2NN4LUsO4rIilscw==",
       "dependencies": {
         "@types/elliptic": "^6.4.14",
         "@types/lodash": "^4.14.177",

--- a/packages/coin-dot/package.json
+++ b/packages/coin-dot/package.json
@@ -17,7 +17,7 @@
     "publish-single": "rm -rf node_modules && npm install && npm run build && npm publish"
   },
   "dependencies": {
-    "@coolwallet/core": "^2.0.0",
+    "@coolwallet/core": "^2.0.8-beta.0",
     "@polkadot/keyring": "^6.0.5",
     "@types/node": "^14.0.13",
     "blake2b": "^2.1.3",

--- a/packages/coin-dot/src/utils/transactionUtil.ts
+++ b/packages/coin-dot/src/utils/transactionUtil.ts
@@ -25,19 +25,19 @@ export function pubKeyToAddress(compressedPubkey: string, addressType: number): 
 export async function getCompleteSignature(
   transport: types.Transport,
   publicKey: string,
-  canonicalSignature: { r: string; s: string; s32?: string } | Buffer
+  canonicalSignature: { r: string; s: string; s32: string } | Buffer
 ): Promise<string> {
   if (Buffer.isBuffer(canonicalSignature)) {
     return '';
   }
-  const { r, s } = canonicalSignature; // without s32
+  const { r, s32 } = canonicalSignature;
   const { signedTx } = await tx.command.getSignedHex(transport);
   const keyPair = ec.keyFromPublic(publicKey, 'hex');
   const payloaBlake2bHash = blake2b(signedTx);
   const v = ec.getKeyRecoveryParam(payloaBlake2bHash, canonicalSignature, keyPair.pub);
   console.debug('v: ', v);
 
-  const sig = r + s + v.toString().padStart(2, '0');
+  const sig = r + s32 + v.toString().padStart(2, '0');
   return sig;
 }
 

--- a/packages/coin-trx/package-lock.json
+++ b/packages/coin-trx/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@coolwallet/core": "^2.0.0",
+        "@coolwallet/core": "^2.0.8-beta.0",
         "@types/node": "14.14.10",
         "base58": "^2.0.1",
         "bignumber.js": "^9.0.1",
@@ -1481,9 +1481,9 @@
       }
     },
     "node_modules/@coolwallet/core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@coolwallet/core/-/core-2.0.0.tgz",
-      "integrity": "sha512-lXtRFawJyV/0BtXlWVgm0H/B/8tvVtHUgHCQCwhPDoa5uCbg9gW8R3JKLepq5NnGXd1IPu8xqMt/hzxh2t+6Ww==",
+      "version": "2.0.8-beta.0",
+      "resolved": "https://registry.npmjs.org/@coolwallet/core/-/core-2.0.8-beta.0.tgz",
+      "integrity": "sha512-vVaQUxitah6ehPb3a9TSv2u2H5Ehc26xprPwbuRYavdQ2jaVZ8fsaHWcmuEe9VCKveKzDg2NN4LUsO4rIilscw==",
       "dependencies": {
         "@types/elliptic": "^6.4.14",
         "@types/lodash": "^4.14.177",
@@ -1504,9 +1504,9 @@
       }
     },
     "node_modules/@coolwallet/core/node_modules/bn.js": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
-      "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
+      "integrity": "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w=="
     },
     "node_modules/@ethereumjs/rlp": {
       "version": "4.0.1",
@@ -1595,9 +1595,9 @@
       }
     },
     "node_modules/@types/bn.js": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
-      "integrity": "sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.2.0.tgz",
+      "integrity": "sha512-DLbJ1BPqxvQhIGbeu8VbUC1DiAiahHtAYvA0ZEAa4P31F7IaArc8z3C3BRQdWX4mtLQuABG4yzp76ZrS02Ui1Q==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -1611,17 +1611,17 @@
       }
     },
     "node_modules/@types/elliptic": {
-      "version": "6.4.14",
-      "resolved": "https://registry.npmjs.org/@types/elliptic/-/elliptic-6.4.14.tgz",
-      "integrity": "sha512-z4OBcDAU0GVwDTuwJzQCiL6188QvZMkvoERgcVjq0/mPM8jCfdwZ3x5zQEVoL9WCAru3aG5wl3Z5Ww5wBWn7ZQ==",
+      "version": "6.4.18",
+      "resolved": "https://registry.npmjs.org/@types/elliptic/-/elliptic-6.4.18.tgz",
+      "integrity": "sha512-UseG6H5vjRiNpQvrhy4VF/JXdA3V/Fp5amvveaL+fs28BZ6xIKJBPnUPRlEaZpysD9MbpfaLi8lbl7PGUAkpWw==",
       "dependencies": {
         "@types/bn.js": "*"
       }
     },
     "node_modules/@types/lodash": {
-      "version": "4.14.178",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.178.tgz",
-      "integrity": "sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw=="
+      "version": "4.17.24",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
+      "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ=="
     },
     "node_modules/@types/node": {
       "version": "14.14.10",
@@ -1629,9 +1629,9 @@
       "integrity": "sha512-J32dgx2hw8vXrSbu4ZlVhn1Nm3GbeCFNw2FWL8S5QKucHGY0cyNwjdQdO+KMBZ4wpmC7KhLCiNsdk1RFRIYUQQ=="
     },
     "node_modules/@types/pbkdf2": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.0.tgz",
-      "integrity": "sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.2.tgz",
+      "integrity": "sha512-uRwJqmiXmh9++aSu1VNEn3iIxWOhd8AHXNSdlaLfdAAdSTY9jYVeGWnzejM3dvrkbqE3/hyQkQQ29IFATEGlew==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -1995,25 +1995,17 @@
       "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ=="
     },
     "node_modules/bip39": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.0.4.tgz",
-      "integrity": "sha512-YZKQlb752TrUWqHWj7XAwCSjYEgGAk+/Aas3V7NyjQeZYsztO8JnQUaCWhcnL4T+jL8nvB8typ2jRPzTlgugNw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.1.0.tgz",
+      "integrity": "sha512-c9kiwdk45Do5GL0vJMe7tS95VjCii65mYAH7DfWl3uW8AVzXKQVUm64i3hzVybBDMp9r7j9iNxR85+ul8MdN/A==",
       "dependencies": {
-        "@types/node": "11.11.6",
-        "create-hash": "^1.1.0",
-        "pbkdf2": "^3.0.9",
-        "randombytes": "^2.0.1"
+        "@noble/hashes": "^1.2.0"
       }
-    },
-    "node_modules/bip39/node_modules/@types/node": {
-      "version": "11.11.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.6.tgz",
-      "integrity": "sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ=="
     },
     "node_modules/bip66": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
-      "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
+      "integrity": "sha512-nemMHz95EmS38a26XbbdxIYj5csHd3RMP3H5bwQknX0WYHF01qhpufP42mLOwVICuH2JmhIhXiWs89MfUGL7Xw==",
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
@@ -2488,9 +2480,7 @@
     "node_modules/core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true,
-      "optional": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "node_modules/crc-32": {
       "version": "1.2.2",
@@ -3231,16 +3221,17 @@
       }
     },
     "node_modules/hash-base": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
-      "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.2.tgz",
+      "integrity": "sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg==",
       "dependencies": {
         "inherits": "^2.0.4",
-        "readable-stream": "^3.6.0",
-        "safe-buffer": "^5.2.0"
+        "readable-stream": "^2.3.8",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.1"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">= 0.8"
       }
     },
     "node_modules/hash.js": {
@@ -3556,9 +3547,7 @@
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true,
-      "optional": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "node_modules/isobject": {
       "version": "3.0.1",
@@ -3638,9 +3627,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -3988,18 +3977,19 @@
       "dev": true
     },
     "node_modules/pbkdf2": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
-      "integrity": "sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.5.tgz",
+      "integrity": "sha512-Q3CG/cYvCO1ye4QKkuH7EXxs3VC/rI1/trd+qX2+PolbaKG0H+bgcZzrTt96mMyRtejk+JMCiLUn3y29W8qmFQ==",
       "dependencies": {
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4",
-        "ripemd160": "^2.0.1",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "ripemd160": "^2.0.3",
+        "safe-buffer": "^5.2.1",
+        "sha.js": "^2.4.12",
+        "to-buffer": "^1.2.1"
       },
       "engines": {
-        "node": ">=0.12"
+        "node": ">= 0.10"
       }
     },
     "node_modules/picomatch": {
@@ -4045,17 +4035,7 @@
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "node_modules/react-native-ble-plx": {
       "version": "2.0.3",
@@ -4063,17 +4043,23 @@
       "integrity": "sha512-62LRDBPf/03K7sge+qq2ZuF8PWCGB782G+SBrpgNm5fA5Hs3FCY1ExTJZ1G0tB5ZhBPYEXcKRxPLuFegcDFrqA=="
     },
     "node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
+    },
+    "node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/readdirp": {
       "version": "2.2.1",
@@ -4088,39 +4074,6 @@
       },
       "engines": {
         "node": ">=0.10"
-      }
-    },
-    "node_modules/readdirp/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/readdirp/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/readdirp/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/regenerate": {
@@ -4273,24 +4226,32 @@
       }
     },
     "node_modules/ripemd160": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
-      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.3.tgz",
+      "integrity": "sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==",
       "dependencies": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1"
+        "hash-base": "^3.1.2",
+        "inherits": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/rlp": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.6.tgz",
-      "integrity": "sha512-HAfAmL6SDYNWPUOJNrM500x4Thn4PZsEy5pijPh40U9WfNk0z15hUYzO9xVIMAdIHdFtD8CBDHd75Td1g36Mjg==",
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.7.tgz",
+      "integrity": "sha512-d5gdPmgQ0Z+AklL2NVXr/IoSjNZFfTVvQWzL/AM2AOcSzYP2xjlb0AC8YyCLc41MSNf6P6QVtjgPdmVtzb+4lQ==",
       "dependencies": {
-        "bn.js": "^4.11.1"
+        "bn.js": "^5.2.0"
       },
       "bin": {
         "rlp": "bin/rlp"
       }
+    },
+    "node_modules/rlp/node_modules/bn.js": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
+      "integrity": "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w=="
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -4402,15 +4363,22 @@
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
     "node_modules/sha.js": {
-      "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+      "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
       "dependencies": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.0"
       },
       "bin": {
         "sha.js": "bin.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/slash": {
@@ -4636,12 +4604,17 @@
       }
     },
     "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dependencies": {
-        "safe-buffer": "~5.2.0"
+        "safe-buffer": "~5.1.0"
       }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/supports-color": {
       "version": "5.5.0",
@@ -4670,6 +4643,24 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/to-buffer": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+      "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+      "dependencies": {
+        "isarray": "^2.0.5",
+        "safe-buffer": "^5.2.1",
+        "typed-array-buffer": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/to-buffer/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
     },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
@@ -4740,6 +4731,19 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/typeforce": {
       "version": "1.18.0",

--- a/packages/coin-trx/package.json
+++ b/packages/coin-trx/package.json
@@ -17,7 +17,7 @@
     "ci-test-report": "NODE_ENV=production jest --no-bail --runInBand --reporters=default --reporters=jest-junit --testResultsProcessor=jest-junit"
   },
   "dependencies": {
-    "@coolwallet/core": "^2.0.0",
+    "@coolwallet/core": "^2.0.8-beta.0",
     "@types/node": "14.14.10",
     "base58": "^2.0.1",
     "bignumber.js": "^9.0.1",

--- a/packages/coin-trx/src/sign.ts
+++ b/packages/coin-trx/src/sign.ts
@@ -62,12 +62,12 @@ export const signTransaction = async (
   );
 
   if (Buffer.isBuffer(canonicalSignature)) return '';
-  const { r, s } = canonicalSignature;
+  const { r, s32 } = canonicalSignature;
   const { signedTx } = await tx.command.getSignedHex(transport);
   const keyPair = ec.keyFromPublic(publicKey, 'hex');
   const v = ec.getKeyRecoveryParam(sha256(Buffer.from(signedTx, 'hex')), canonicalSignature, keyPair.pub);
 
-  const sig = r + s + v.toString().padStart(2, '0');
+  const sig = r + s32 + v.toString().padStart(2, '0');
 
   return '0a' + toVarint(signedTx.length / 2) + signedTx + '12' + toVarint(sig.length / 2) + sig;
 };


### PR DESCRIPTION
## Overview

This PR fixes the signature assembly for coin-dot and coin-trx by switching from `s` to `s32` (the 32-byte padded format), ensuring signatures are constructed correctly when the hardware wallet returns a padded s value.

## Key Changes

- Updated `getCompleteSignature` in coin-dot to require `s32` (changed from optional to required) and use it in final signature assembly instead of `s`.
- Updated `signTransaction` in coin-trx to destructure and use `s32` instead of `s` when constructing the signature hex.
- Bumped `@coolwallet/core` to `^2.0.8-beta.0` in both `coin-dot` and `coin-trx` packages.

## Verification

- Manually verified diff aligns with CW-28266 fix intent (s32 support for TRX and DOT).

## Related

- Task: https://app.clickup.com/t/CW-28266
 
 
 
 
 
 
 
 **PR Summary by Typo**
------------

#### Overview
This PR addresses a bug in the `coin-dot` and `coin-trx` packages by ensuring the `s32` component of the signature is used instead of `s` for correct transaction signing. It also updates the `@coolwallet/core` dependency and enhances the CI workflow to wait for the JCVM service.

#### Key Changes
- Modified signature generation logic in `coin-dot` and `coin-trx` to use `s32` instead of `s` for canonical signatures.
- Updated the `@coolwallet/core` dependency to version `^2.0.8-beta.0` in both `coin-dot` and `coin-trx` packages, leading to `package-lock.json` updates.
- Added a `Wait for JCVM to be ready` step in the GitHub Actions workflow to improve CI stability.

#### Work Breakdown

| Category | Lines Changed |
|----------|---------------|
| New Work | 73 (34.6%) |
| Churn | 54 (25.6%) |
| Rework | 84 (39.8%) |
| Total Changes | 211 | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>