### PR TITLE
feat(core): add optional loadScript param to updateSE / updateSEPart1

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coolwallet/core",
-  "version": "2.0.8-beta.0",
+  "version": "2.0.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@coolwallet/core",
-      "version": "2.0.8-beta.0",
+      "version": "2.0.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/elliptic": "^6.4.14",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coolwallet/core",
-  "version": "2.0.8-beta.0",
+  "version": "2.0.9",
   "description": "Core library for other CoolWallet SDKs.",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/core/src/apdu/ota/ota.ts
+++ b/packages/core/src/apdu/ota/ota.ts
@@ -135,6 +135,7 @@ interface UpdateSeParams {
   callAPI: (url: string, options: APIOptions) => Promise<any>;
   updateMCU?: boolean;
   apiSecret: string;
+  loadScript?: string;
 }
 
 /**
@@ -146,6 +147,7 @@ interface UpdateSeParams {
  * @param progressCallback progressCallback(progressNum): return update progress percentage
  * @param callAPI callAPI(url, options): Function of calling api
  * @param updateMCU
+ * @param loadScript override the default loadScript; used for testing specific firmware versions
  */
 export const updateSE = async ({
   transport,
@@ -156,6 +158,7 @@ export const updateSE = async ({
   callAPI,
   updateMCU = false,
   apiSecret,
+  loadScript,
 }: UpdateSeParams): Promise<number> => {
   const SCRIPT = getScripts(transport.cardType);
   const progress = new Progress(getProgressNums(updateMCU));
@@ -178,7 +181,13 @@ export const updateSE = async ({
     console.debug('Delete Card Manager Done');
 
     progressCallback(progress.next()); // progress 50
-    await insertLoadScript(transport, SCRIPT.loadScript, progressCallback, progress.current(), progress.next()); // From progress 50 to progress 88
+    await insertLoadScript(
+      transport,
+      loadScript ?? SCRIPT.loadScript,
+      progressCallback,
+      progress.current(),
+      progress.next()
+    ); // From progress 50 to progress 88
     console.debug('Load OTA Script Done');
 
     await insertScript(transport, SCRIPT.installScript);
@@ -210,6 +219,7 @@ export const updateSEPart1 = async ({
   callAPI,
   updateMCU = false,
   apiSecret,
+  loadScript,
 }: UpdateSeParams): Promise<void> => {
   const SCRIPT = getScripts(transport.cardType);
   const progress = new Progress(getProgressNums(updateMCU));
@@ -239,7 +249,13 @@ export const updateSEPart1 = async ({
 
     progressCallback(progress.next()); // progress 50
     console.log('updateSEPart1 >> insertLoadScript');
-    await insertLoadScript(transport, SCRIPT.loadScript, progressCallback, progress.current(), progress.next()); // From progress 50 to progress 88
+    await insertLoadScript(
+      transport,
+      loadScript ?? SCRIPT.loadScript,
+      progressCallback,
+      progress.current(),
+      progress.next()
+    ); // From progress 50 to progress 88
     console.debug('Load OTA Script Done');
 
     console.log('updateSEPart1 >> insertScript');


### PR DESCRIPTION
## Summary

- Add `loadScript?: string` to `UpdateSeParams` interface
- `updateSE` and `updateSEPart1` now use `loadScript ?? SCRIPT.loadScript`, falling back to the bundled default when not provided
- Enables app-side testing of specific Go card firmware versions without changing the SDK's bundled script

## Test plan

- [x] Normal OTA update (no `loadScript` passed) still works as before
- [x] Passing a custom `loadScript` loads that script instead of the default

🤖 Generated with [Claude Code](https://claude.com/claude-code)
 
 **PR Summary by Typo**
------------

#### Overview
This PR introduces an optional `loadScript` parameter to the `updateSE` and `updateSEPart1` functions, enabling the override of the default load script for specific firmware testing.

#### Key Changes
- Added an optional `loadScript` parameter to the `UpdateSeParams` interface.
- Modified `updateSE` and `updateSEPart1` functions to utilize the provided `loadScript` if present, otherwise defaulting to the standard script.
- Updated the package version from `2.0.8-beta.0` to `2.0.9` in `package.json` and `package-lock.json`.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 16 (76.2%)    |
| Rework      | 5 (23.8%)     |
| Total Changes | 21            | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>