### PR TITLE
🐛 💚 [CW-28891] fix(action): 升級 allure-report-action 到 v1.15 修復報告產生失敗

### DIFF
--- a/.github/workflows/test-and-generate-report.yml
+++ b/.github/workflows/test-and-generate-report.yml
@@ -179,7 +179,7 @@ jobs:
         mv -v ./result/* ./allure-results/
         
     - name: Build Test Report
-      uses: simple-elf/allure-report-action@v1.13
+      uses: simple-elf/allure-report-action@v1.15
       if: always()
       with:
         gh_pages: gh-pages


### PR DESCRIPTION
> ⚠️ Code review gate skipped (--skip-review); reviewer 請自行留意 diff 品質。

## Overview

`report` job 的 `Build Test Report` step 自 2026-07-24 起持續失敗，讓所有 PR 的 CI 無法轉綠，且 Allure 測試報告已默默停止發布約 12 個 run。本 PR 把 `simple-elf/allure-report-action` 從 v1.13 升到 v1.15，取用上游已修好「base image 不再內建 `xargs`」的版本。

## Key Changes

- 將 `.github/workflows/test-and-generate-report.yml` 的 `Build Test Report` step 由 `simple-elf/allure-report-action@v1.13` 升級到 `@v1.15`，取用上游 [issue #77](https://github.com/simple-elf/allure-report-action/issues/77) / PR #78（`add findutils to dockerfile`）的修復；根因是該 Docker action 的 base image `public.ecr.aws/amazoncorretto/amazoncorretto:8` 自 2026-07-24 起不再內建 `xargs`，而 Allure CLI 的 `bin/allure` 是 Gradle 產生的 start script，內含 `command -v xargs || die "xargs is not available"` 硬性檢查，導致 `allure generate` 啟動即死、`allure-report/` 從未產生，連鎖出 `cp: cannot stat './allure-report/.'` 並讓整個 job 失敗。
- 沿用 `v1.15` tag 而非釘 commit SHA，與 repo 內其他 action 的釘法一致（例如上一支 workflow 修復 8af87a38d）；注意 `v1.14` 不含此修復（僅 Allure 2.42.0 bump），必須跳到 v1.15。
- 刻意把這支 PR 收斂成單行改動以降低風險：排查過程另外發現兩個既有問題（`Publish test report` 因 root 所有的 `allure-history/.git` 吃 EACCES 卻仍回報 success 的 silent failure；以及測試失敗時 `report` job 會被 skip 導致 Slack 通知形同 dead code），已完整記錄在 CW-28891 作為 follow-up，不在本 PR 處理。

## Verification

- 以 `gh run view 30442802836 --json jobs` 確認 `report` job 只有 `Build Test Report` 一個 step 是 failure，而最初被回報的 `Publish test report` 其實是 success，藉此定位真正的失敗點。
- 讀取 v1.13 與 v1.15 的 Dockerfile 確認 v1.13 只 `yum install tar wget gzip`、v1.15 已補上 `findutils`；並比對 Gradle `unixStartScript.txt` 模板確認 `die "xargs is not available"` 這段硬性檢查的來源。
- 比對 `v1.13...v1.15` 確認只有 `Dockerfile` 一個檔案變動（另含 Allure 2.32.0 → 2.44.0），`entrypoint.sh` 未變，因此 inputs 與 `allure-history/<subfolder>/<run_number>` 輸出結構皆無 breaking change。
- 以 `gh api "repos/CoolBitX-Technology/coolwallet-sdk/contents/all-services?ref=gh-pages"` 確認 gh-pages 目前只發布到 `435 436 437 438`、而 run number 已到 450，量化這次故障的影響範圍。
- `git diff` 確認本 PR 僅一行變動（只有 action 版本號那行）。

## Related

- Task: https://app.clickup.com/t/CW-28891

 
 **PR Summary by Typo**
------------

#### Overview
This PR upgrades the `allure-report-action` GitHub Action from version `v1.13` to `v1.15` in the CI workflow to resolve an issue causing test report generation to fail.

#### Key Changes
- Updated `simple-elf/allure-report-action` from version `v1.13` to `v1.15` in `.github/workflows/test-and-generate-report.yml`.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| Refactor    | 1 (100.0%)    |
| Total Changes | 1           | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>