### PR TITLE
✅ [CW-28804] chore(sol): 補齊 Solana 官方 token Pro 卡顯示測試

### DIFF
--- a/packages/coin-sol/tests/index.spec.ts
+++ b/packages/coin-sol/tests/index.spec.ts
@@ -41,7 +41,6 @@ function omit<T extends Record<string, any>>(obj: T, key: keyof T) {
 describe('Test Solana SDK', () => {
   const tokens = Object.values(TOKEN_INFO);
   const getRandInt = (max: number) => Math.floor(Math.random() * max);
-  const getRandToken = () => omit(tokens[getRandInt(tokens.length)], 'signature');
   const getRandWallet = () => stringUtil.pubKeyToAddress(crypto.randomBytes(32).toString('hex'));
 
   let props: PromiseValue<ReturnType<typeof initialize>>;
@@ -159,7 +158,7 @@ describe('Test Solana SDK', () => {
     expect(display).toEqual(expectedTxDetail.toLowerCase());
   });
 
-  it('Test SPL Token Transaction', async () => {
+  it.each(tokens)('Test SPL Token Transaction $symbol', async (officialToken) => {
     const addressIndex = 0;
     const node = wallet.derivePath(bip32Path(addressIndex));
     const expectedWallet = Keypair.fromSeed(node.privateKey);
@@ -167,7 +166,9 @@ describe('Test Solana SDK', () => {
     const fromTokenAccount = getRandWallet();
     const toTokenAccount = getRandWallet();
     const recentBlockhash = getRandWallet();
-    const tokenInfo = getRandToken();
+    // 不帶 signature，讓 SDK 依 token address 自行從官方清單取回官方簽名。
+    // 官方簽名有效時 Pro 卡顯示純 symbol；簽名錯誤或缺漏才會退化成三條線。
+    const tokenInfo = omit(officialToken, 'signature');
     const amount = getRandInt(10 * 10 ** tokenInfo.decimals) + 1;
 
     const signTxData = {


### PR DESCRIPTION
## Overview

CW-28804 這個 sprint 在 ETH / Base / Arbitrum / Solana 四條鏈加上 USDS 官方 token。本 PR 補上驗證「官方簽名有效、Pro 卡不會顯示三條線」的測試覆蓋。盤點後發現只有 Solana 缺覆蓋，因此改動集中在 coin-sol。

## Key Changes

- 把 `Test SPL Token Transaction` 從 `it` 改成 `it.each(tokens)`，逐一跑過 `TOKEN_INFO` 全部 9 個官方 token。原本用 `getRandToken()` 每次只隨機抽一個 token，這個 sprint 新增的 USDS 只有 1/9 機率被跑到，等於沒有覆蓋。
- 沿用原本「傳入 tokenInfo 時不帶 signature」的作法（`omit(officialToken, 'signature')`），讓 SDK 依 token address 從官方清單自行回填簽名（`packages/coin-sol/src/index.ts:110`），一個測試同時驗證「自動找官方 token」與「官方簽名有效」兩個合約 — 官方簽名有效時 Pro 卡顯示純 symbol，簽錯或缺漏才會退化成三條線。
- 加上 comment 說明為什麼刻意不帶 signature，避免後人以為是漏傳。
- 移除只剩一處呼叫的 `getRandToken` helper。

已盤點確認不需調整的部分：ETH 走 `it.each(TOKENTYPE)`（`packages/coin-eth/tests/index.spec.ts`）；Base / Arbitrum 走 `it.each(Object.values(api.chain.tokens))`（`packages/coin-evm/tests/index.spec.ts`），兩條鏈都在 coin-evm 的 `TEST_COINS` 內，legacy 與 EIP1559 兩條 ERC20 路徑都已逐 token 迭代，USDS 已被覆蓋。

## Verification

四條鏈的完整測試都已在卡上跑過，全綠：

| Package | Test Suites | Tests | Snapshots | Time |
|---|---|---|---|---|
| `coin-sol` | 2 passed / 2 | **32 passed / 32** | 13 passed / 13 | 4.2s |
| `coin-evm` | 1 passed / 1 | **792 passed / 792** | — | 257.6s |
| `coin-eth` | 1 passed / 1 | **617 passed / 617** | — | 157.6s |

- coin-sol 的 32 = 13（`scriptUtil.test.ts`）+ 10（`index.spec.ts` 原有 `it`）+ **9（本 PR 新增的 `it.each` 逐 token 迭代）**，數字對得上，確認 `TOKEN_INFO` 全部 9 個官方 token 皆已實際執行且顯示正確，含本 sprint 新增的 **USDS**。
- coin-evm 792 passed 涵蓋 Base 與 Arbitrum 的 legacy + EIP1559 ERC20 路徑，USDS 官方簽名顯示正確。
- coin-eth 617 passed 涵蓋 `TOKENTYPE` 全部官方 token，USDS 官方簽名顯示正確。
- 改動檔案 tsc `--strict` 通過（確認 `it.each` 的 `officialToken` 型別推導正常），eslint 0 errors（只剩 4 個既有 warning）。
- 確認 9 個官方 token symbol 全部唯一、全大寫、≤7 字元 → 無 `it.each` title 衝突，也不會撞到 SE 端 `slice(0, 7).toUpperCase()` 的正規化；decimals 最大為 10，`getRandInt(10 * 10 ** 10)` 在 safe integer 範圍內，`BigInt(amount)` 不會 throw。
- Ran swiss-knife:code-review — no blocking findings.

### 一併驗證掉的既有風險

這個改動把先前只有 1/9 機率跑到的 token 變成每次都跑，其中 GMT（9 decimals）與 ORDER（10 decimals）超過 `DisplayBuilder.amountPage` 保留的 8 位小數（`ROUND_DOWN`）。原本擔心 SE 端的截斷規則跟 DisplayBuilder 不一致會導致這兩個 token 穩定 fail（repo 有 `fix(testing-library): decimals overflow issue in display.ts` 的前例）。實測 32 tests 全過，兩者行為一致，此風險確認不存在。

## Related

- Task: https://app.clickup.com/t/25577573/CW-28804

 
 **PR Summary by Typo**
------------

#### Overview
This PR updates the Solana SDK test suite to iterate over all official tokens rather than using a single randomized one, ensuring comprehensive test coverage for SPL token transactions and Pro card display logic.

#### Key Changes
- Replaced the single randomized token test with `it.each(tokens)` to test transaction generation for every official Solana token.
- Updated `tokenInfo` generation to explicitly omit the signature, forcing the SDK to fetch the official signature from the token list.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 2 (40.0%)     |
| Churn       | 1 (20.0%)     |
| Refactor    | 2 (40.0%)     |
| Total Changes | 5           | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>