### PR TITLE
chore(ci): CI workflow 加固（CW-28893）

### DIFF
--- a/.github/workflows/test-and-generate-report.yml
+++ b/.github/workflows/test-and-generate-report.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         repository: CoolBitX-Technology/coolwallet-sdk
         path: sdk
-        ref: ${{ github.event.pull_request.head.ref }}
+        ref: ${{ github.event.pull_request.head.sha }}
         submodules: recursive
         token: ${{ secrets.DEVOPS_READ_PACKAGE_TOKEN }}
 

--- a/.github/workflows/test-and-generate-report.yml
+++ b/.github/workflows/test-and-generate-report.yml
@@ -71,15 +71,16 @@ jobs:
     - name: Wait for JCVM to be ready
       run: |
         echo "Waiting for JCVM HTTP service on port 9527..."
-        for i in $(seq 1 30); do
+        for i in $(seq 1 90); do
           if curl -s -o /dev/null --max-time 2 http://localhost:9527/ 2>/dev/null; then
             echo "JCVM is ready (attempt $i)"
             exit 0
           fi
-          echo "Attempt $i/30 - not ready yet, waiting 2s..."
+          echo "Attempt $i/90 - not ready yet, waiting 2s..."
           sleep 2
         done
-        echo "JCVM failed to start after 60 seconds"
+        echo "JCVM failed to start after 180 seconds"
+        docker ps -a --filter name=coolwallet-jcvm-jre-http
         docker logs coolwallet-jcvm-jre-http
         exit 1
 


### PR DESCRIPTION
## Summary
- 拉長 `Wait for JCVM to be ready` 的等待 timeout（60s → 180s），避免容器冷啟動（Gradle daemon/buildSrc 編譯）造成的隨機 flake，並補上 `docker ps -a` 方便判斷容器狀態
- `Checkout code` 的 `ref:` 改用 PR head commit SHA（`head.sha`）取代使用者可控的 branch 名稱（`head.ref`），消除 ref confusion/injection 風險，語意不變

CW-28893: https://app.clickup.com/t/25577573/CW-28893

## Commits
- `fix(ci): 拉長 JCVM 就緒等待 timeout 避免冷啟動造成 flake`
- `fix(ci): checkout 改用 PR head commit SHA 取代 branch 名稱`

## Test plan
- [x] JCVM timeout：健康 run 耗時與改動前相同（21 次 attempt / 42 秒就緒，curl 一成功即提早結束），log 格式正確顯示 `Attempt x/90`（run [30992449146](https://github.com/CoolBitX-Technology/coolwallet-sdk/actions/runs/30992449146)）
- [x] checkout ref：改用 `head.sha` 後確認 checkout 拿到的 commit 正確（PR headRefOid `89a6287...` 對上 `HEAD is now at 89a6287`），且 `git diff upstream/master` 算出的 `modified_coins` 與改動前一致（run [30993820646](https://github.com/CoolBitX-Technology/coolwallet-sdk/actions/runs/30993820646)）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

 
 **PR Summary by Typo**
------------

#### Overview
This PR hardens the CI workflow by updating checkout references to use the specific commit SHA instead of the branch ref and increasing the timeout and retry attempts for the JCVM service readiness check.

#### Key Changes
- Updated the checkout action to use `${{ github.event.pull_request.head.sha }}` for improved determinism.
- Extended the JCVM service startup timeout from 60 seconds to 180 seconds (90 attempts).
- Added Docker container status inspection (`docker ps`) upon JCVM startup failure to aid debugging.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 1 (20.0%)     |
| Refactor    | 4 (80.0%)     |
| Total Changes | 5           | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>