### PR TITLE
🐛 [CW-28884] fix(core): getCanonicalSignature 補上 r32 padding

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coolwallet/core",
-  "version": "2.0.9",
+  "version": "2.0.10-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@coolwallet/core",
-      "version": "2.0.9",
+      "version": "2.0.10-beta.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/elliptic": "^6.4.14",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coolwallet/core",
-  "version": "2.0.9",
+  "version": "2.0.10-beta.0",
   "description": "Core library for other CoolWallet SDKs.",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/core/src/crypto/signature.ts
+++ b/packages/core/src/crypto/signature.ts
@@ -61,13 +61,15 @@ export const getCanonicalSignature = (signature: { s: string; r: string}) => {
   
   // handing r
   const rBigNumber = r.toString(16);
+  const r32 = rBigNumber.padStart(64, '0');
   const rlength = rBigNumber.length % 2 === 0 ? rBigNumber.length : rBigNumber.length + 1;
   const canonicalR = rBigNumber.padStart(rlength, '0');
 
   const canonicalSignature = {
     r: canonicalR,
     s: canonicalS,
-    s32: s32,
+    r32,
+    s32,
   };
 
   return canonicalSignature;

--- a/packages/core/src/transaction/util.ts
+++ b/packages/core/src/transaction/util.ts
@@ -7,9 +7,9 @@ import { SignatureType } from './type';
  *
  * @param {String} signature
  * @param {String} signatureType
- * @returns {{r:string, s:string, s32: string} | Buffer } Buffer or DER signature
+ * @returns {{r:string, s:string, r32:string, s32: string} | Buffer } Buffer or DER signature
  */
-export const formatSignature = (signature: string, signatureType: SignatureType): { r: string; s: string; s32: string } | Buffer => {
+export const formatSignature = (signature: string, signatureType: SignatureType): { r: string; s: string; r32: string; s32: string } | Buffer => {
   const iv = Buffer.alloc(16);
   iv.fill(0);
   const sigBuff = Buffer.from(signature, 'hex');
@@ -37,13 +37,13 @@ export const formatSignature = (signature: string, signatureType: SignatureType)
  * @param {String} encryptedSignature
  * @param {String} signatureKey
  * @param {SignatureType} signatureType
- * @return {{r:string, s:string, s32: string} | Buffer } Buffer or DER signature
+ * @return {{r:string, s:string, r32:string, s32: string} | Buffer } Buffer or DER signature
  */
 export const decryptSignatureFromSE = (
   encryptedSignature: string,
   signatureKey: string,
   signatureType: SignatureType
-): { r: string; s: string; s32: string } | Buffer => {
+): { r: string; s: string; r32: string; s32: string } | Buffer => {
   const iv = Buffer.alloc(16);
   iv.fill(0);
   const sigBuff = aes256CbcDecrypt(iv, Buffer.from(signatureKey, 'hex'), encryptedSignature);

--- a/packages/core/tests/utils/signature.spec.ts
+++ b/packages/core/tests/utils/signature.spec.ts
@@ -1,0 +1,50 @@
+import { getCanonicalSignature } from '../../src/crypto/signature';
+
+describe('getCanonicalSignature', () => {
+  it('r32 is always 64 hex chars when r has a leading-zero byte', () => {
+    // r < 2^248 means the highest byte is 0x00 → previously dropped, causing a 63-byte r
+    const r = '00' + 'ab'.repeat(31);
+    const s = 'cd'.repeat(32);
+    const result = getCanonicalSignature({ r, s });
+
+    expect(result.r32).toHaveLength(64);
+    expect(result.r32.startsWith('00')).toBe(true);
+  });
+
+  it('r32 is always 64 hex chars for a normal r value', () => {
+    const r = 'ab'.repeat(32);
+    const s = 'cd'.repeat(32);
+    const result = getCanonicalSignature({ r, s });
+
+    expect(result.r32).toHaveLength(64);
+  });
+
+  it('s32 is always 64 hex chars when s has a leading-zero byte', () => {
+    const r = 'ab'.repeat(32);
+    const s = '00' + 'cd'.repeat(31);
+    const result = getCanonicalSignature({ r, s });
+
+    expect(result.s32).toHaveLength(64);
+    expect(result.s32.startsWith('00')).toBe(true);
+  });
+
+  it('preserves existing r, s, s32 fields for backward compatibility', () => {
+    const r = 'ab'.repeat(32);
+    const s = 'cd'.repeat(32);
+    const result = getCanonicalSignature({ r, s });
+
+    expect(result).toHaveProperty('r');
+    expect(result).toHaveProperty('s');
+    expect(result).toHaveProperty('s32');
+    expect(result).toHaveProperty('r32');
+  });
+
+  it('r32 and s32 are both 64 hex chars regardless of leading-zero bytes', () => {
+    const r = '00' + 'ef'.repeat(31);
+    const s = '00' + '12'.repeat(31);
+    const result = getCanonicalSignature({ r, s });
+
+    expect(result.r32).toHaveLength(64);
+    expect(result.s32).toHaveLength(64);
+  });
+});

--- a/packages/core/tests/utils/signature.spec.ts
+++ b/packages/core/tests/utils/signature.spec.ts
@@ -1,4 +1,6 @@
-import { getCanonicalSignature } from '../../src/crypto/signature';
+import { getCanonicalSignature, convertToDER } from '../../src/crypto/signature';
+import { formatSignature } from '../../src/transaction/util';
+import { SignatureType } from '../../src/transaction/type';
 
 describe('getCanonicalSignature', () => {
   it('r32 is always 64 hex chars when r has a leading-zero byte', () => {
@@ -46,5 +48,23 @@ describe('getCanonicalSignature', () => {
 
     expect(result.r32).toHaveLength(64);
     expect(result.s32).toHaveLength(64);
+  });
+});
+
+describe('formatSignature — Canonical end-to-end', () => {
+  it('r32 survives the DER parse → canonicalize pipeline when r has a leading-zero byte', () => {
+    // r is 31 significant bytes (< 2^248). convertToDER adds the DER 0x00 high-bit prefix,
+    // so parseDERsignature gives back 31 bytes; without the r32 fix this produced a 62-char r.
+    const r = 'ab'.repeat(31); // 31 bytes, first byte 0xab (high bit set → DER prepends 0x00)
+    const s = '12'.repeat(32);
+
+    const derHex = convertToDER({ r, s }).toString('hex');
+    const result = formatSignature(derHex, SignatureType.Canonical);
+
+    expect(Buffer.isBuffer(result)).toBe(false);
+    if (!Buffer.isBuffer(result)) {
+      expect(result.r32).toHaveLength(64);
+      expect(result.r32.startsWith('00')).toBe(true);
+    }
   });
 });


### PR DESCRIPTION
## Overview

Fix `getCanonicalSignature` in `@coolwallet/core`：補上 `r32`（`r` padding 至 32 bytes / 64 hex chars），與既有 `s32` 對稱。當 `r` 有 leading-zero byte（約 1/256 機率），raw ECDSA 簽名少 1 byte，鏈上驗簽以 "Signature size is 64" 拒絕（Sentry COOLWALLET-3F，220k+ occurrences，1500+ users）。

## Key Changes

- `crypto/signature.ts`：在 `getCanonicalSignature` 加入 `r32 = rBigNumber.padStart(64, '0')`，仿照現有 `s32` 模式，置於偶數補齊之前
- `transaction/util.ts`：`formatSignature` 與 `decryptSignatureFromSE` 回傳型別加上 `r32: string`，讓下游 coin package 能直接取用
- `package.json`：版本 bump 至 `2.0.10-beta.0`
- `tests/utils/signature.spec.ts`：新增 5 個 unit test，覆蓋 r/s leading-zero byte、正常值、backward compatibility 四種情境

> **Note（兩段式發布策略）**：本 PR 範圍僅限 `@coolwallet/core`。TRX、DOT、ICX、ATOM、CRO、TERRA 等 coin package 切換為 `r32` 的改動，待本版本 publish 至 npm 後再另開 PR 處理——各 coin 從 npm 安裝 core，不吃 local source。

## Verification

- Ran `swiss-knife:code-review` — no blocking findings.
- 5 unit tests 覆蓋：r leading-zero（長度 + 前綴 assert）、r 正常值（長度）、s leading-zero（長度 + 前綴 assert）、backward compatibility（r/s/r32/s32 四個欄位都存在）、r 與 s 同時 leading-zero（兩者長度）

## Related

- Task: https://app.clickup.com/t/25577573/CW-28884
 
 
 
 **PR Summary by Typo**
------------

#### Overview
This PR updates the `@coolwallet/core` package to version `2.0.10-beta.0` and fixes signature handling by adding `r32` padding to canonical signatures.

#### Key Changes
- Added `r32` padding to `getCanonicalSignature` to ensure the `r` value is consistently 64 hex characters (32 bytes) long.
- Updated signature formatting and decryption utility return types to include `r32`.
- Added unit tests covering the new `r32` padding behavior and backward compatibility.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 72 (90.0%)    |
| Refactor    | 8 (10.0%)     |
| Total Changes | 80          | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>