### PR TITLE
fix(cro,trx): 修正 npm publish 失敗問題

### DIFF
--- a/packages/coin-cro/package-lock.json
+++ b/packages/coin-cro/package-lock.json
@@ -14,7 +14,6 @@
         "@types/keccak": "^3.0.1",
         "bech32": "^2.0.0",
         "bip32": "^2.0.4",
-        "eth-sig-util": "^3.0.1",
         "keccak": "^3.0.2",
         "protobufjs": "^6.11.2",
         "protocol-buffers": "^4.2.0",
@@ -30,7 +29,6 @@
         "@babel/plugin-proposal-class-properties": "^7.7.4",
         "@babel/preset-env": "^7.7.1",
         "@babel/preset-typescript": "^7.7.7",
-        "@types/eth-sig-util": "^2.1.1",
         "@types/node": "^14.0.13",
         "typescript": "^4.4.3"
       }
@@ -2362,16 +2360,6 @@
         "@types/bn.js": "*"
       }
     },
-    "node_modules/@types/eth-sig-util": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@types/eth-sig-util/-/eth-sig-util-2.5.3.tgz",
-      "integrity": "sha512-ERDoQIZ4sPKMVB+1w9LoGpIs5N74kea6i75UFQD04UFmvRT7dibzPcp6uKQDqUtmdQn2OUV3amnGFpr5aKrhVA==",
-      "deprecated": "This is a stub types definition. eth-sig-util provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "eth-sig-util": "*"
-      }
-    },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
@@ -3752,18 +3740,6 @@
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
       "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ=="
     },
-    "node_modules/eth-sig-util": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-3.0.1.tgz",
-      "integrity": "sha512-0Us50HiGGvZgjtWTyAI/+qTzYPMLy5Q451D0Xy68bxq1QMWdoOddDwGvsqcFT27uohKgalM9z/yxplyt+mY2iQ==",
-      "deprecated": "Deprecated in favor of '@metamask/eth-sig-util'",
-      "dependencies": {
-        "ethereumjs-abi": "^0.6.8",
-        "ethereumjs-util": "^5.1.1",
-        "tweetnacl": "^1.0.3",
-        "tweetnacl-util": "^0.15.0"
-      }
-    },
     "node_modules/ethereum-bloom-filters": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/ethereum-bloom-filters/-/ethereum-bloom-filters-1.2.0.tgz",
@@ -3808,62 +3784,6 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/ethereumjs-abi": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.8.tgz",
-      "integrity": "sha512-Tx0r/iXI6r+lRsdvkFDlut0N08jWMnKRZ6Gkq+Nmw75lZe4e6o3EkSnkaBP5NF6+m5PTGAr9JP43N3LyeoglsA==",
-      "deprecated": "This library has been deprecated and usage is discouraged.",
-      "dependencies": {
-        "bn.js": "^4.11.8",
-        "ethereumjs-util": "^6.0.0"
-      }
-    },
-    "node_modules/ethereumjs-abi/node_modules/@types/bn.js": {
-      "version": "4.11.6",
-      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
-      "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/ethereumjs-abi/node_modules/bn.js": {
-      "version": "4.12.5",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
-      "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ=="
-    },
-    "node_modules/ethereumjs-abi/node_modules/ethereumjs-util": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
-      "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
-      "dependencies": {
-        "@types/bn.js": "^4.11.3",
-        "bn.js": "^4.11.0",
-        "create-hash": "^1.1.2",
-        "elliptic": "^6.5.2",
-        "ethereum-cryptography": "^0.1.3",
-        "ethjs-util": "0.1.6",
-        "rlp": "^2.2.3"
-      }
-    },
-    "node_modules/ethereumjs-util": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-      "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
-      "dependencies": {
-        "bn.js": "^4.11.0",
-        "create-hash": "^1.1.2",
-        "elliptic": "^6.5.2",
-        "ethereum-cryptography": "^0.1.3",
-        "ethjs-util": "^0.1.3",
-        "rlp": "^2.0.0",
-        "safe-buffer": "^5.1.1"
-      }
-    },
-    "node_modules/ethereumjs-util/node_modules/bn.js": {
-      "version": "4.12.5",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
-      "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ=="
-    },
     "node_modules/ethjs-unit": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
@@ -3881,19 +3801,6 @@
       "version": "4.11.6",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
       "integrity": "sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA=="
-    },
-    "node_modules/ethjs-util": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
-      "integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
-      "dependencies": {
-        "is-hex-prefixed": "1.0.0",
-        "strip-hex-prefix": "1.0.0"
-      },
-      "engines": {
-        "node": ">=6.5.0",
-        "npm": ">=3"
-      }
     },
     "node_modules/event-emitter": {
       "version": "0.3.5",
@@ -6492,16 +6399,6 @@
         "node": "*"
       }
     },
-    "node_modules/tweetnacl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
-    },
-    "node_modules/tweetnacl-util": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz",
-      "integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw=="
-    },
     "node_modules/type": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
@@ -8874,15 +8771,6 @@
         "@types/bn.js": "*"
       }
     },
-    "@types/eth-sig-util": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@types/eth-sig-util/-/eth-sig-util-2.5.3.tgz",
-      "integrity": "sha512-ERDoQIZ4sPKMVB+1w9LoGpIs5N74kea6i75UFQD04UFmvRT7dibzPcp6uKQDqUtmdQn2OUV3amnGFpr5aKrhVA==",
-      "dev": true,
-      "requires": {
-        "eth-sig-util": "*"
-      }
-    },
     "@types/http-cache-semantics": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
@@ -9956,17 +9844,6 @@
         }
       }
     },
-    "eth-sig-util": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-3.0.1.tgz",
-      "integrity": "sha512-0Us50HiGGvZgjtWTyAI/+qTzYPMLy5Q451D0Xy68bxq1QMWdoOddDwGvsqcFT27uohKgalM9z/yxplyt+mY2iQ==",
-      "requires": {
-        "ethereumjs-abi": "^0.6.8",
-        "ethereumjs-util": "^5.1.1",
-        "tweetnacl": "^1.0.3",
-        "tweetnacl-util": "^0.15.0"
-      }
-    },
     "ethereum-bloom-filters": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/ethereum-bloom-filters/-/ethereum-bloom-filters-1.2.0.tgz",
@@ -10009,65 +9886,6 @@
         }
       }
     },
-    "ethereumjs-abi": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.8.tgz",
-      "integrity": "sha512-Tx0r/iXI6r+lRsdvkFDlut0N08jWMnKRZ6Gkq+Nmw75lZe4e6o3EkSnkaBP5NF6+m5PTGAr9JP43N3LyeoglsA==",
-      "requires": {
-        "bn.js": "^4.11.8",
-        "ethereumjs-util": "^6.0.0"
-      },
-      "dependencies": {
-        "@types/bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
-          "requires": {
-            "@types/node": "*"
-          }
-        },
-        "bn.js": {
-          "version": "4.12.5",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
-          "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ=="
-        },
-        "ethereumjs-util": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
-          "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
-          "requires": {
-            "@types/bn.js": "^4.11.3",
-            "bn.js": "^4.11.0",
-            "create-hash": "^1.1.2",
-            "elliptic": "^6.5.2",
-            "ethereum-cryptography": "^0.1.3",
-            "ethjs-util": "0.1.6",
-            "rlp": "^2.2.3"
-          }
-        }
-      }
-    },
-    "ethereumjs-util": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-      "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
-      "requires": {
-        "bn.js": "^4.11.0",
-        "create-hash": "^1.1.2",
-        "elliptic": "^6.5.2",
-        "ethereum-cryptography": "^0.1.3",
-        "ethjs-util": "^0.1.3",
-        "rlp": "^2.0.0",
-        "safe-buffer": "^5.1.1"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.12.5",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
-          "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ=="
-        }
-      }
-    },
     "ethjs-unit": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
@@ -10082,15 +9900,6 @@
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
           "integrity": "sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA=="
         }
-      }
-    },
-    "ethjs-util": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
-      "integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
-      "requires": {
-        "is-hex-prefixed": "1.0.0",
-        "strip-hex-prefix": "1.0.0"
       }
     },
     "event-emitter": {
@@ -12097,16 +11906,6 @@
       "requires": {
         "safe-buffer": "^5.0.1"
       }
-    },
-    "tweetnacl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
-    },
-    "tweetnacl-util": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz",
-      "integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw=="
     },
     "type": {
       "version": "2.7.3",

--- a/packages/coin-cro/package.json
+++ b/packages/coin-cro/package.json
@@ -22,7 +22,6 @@
     "@babel/plugin-proposal-class-properties": "^7.7.4",
     "@babel/preset-env": "^7.7.1",
     "@babel/preset-typescript": "^7.7.7",
-    "@types/eth-sig-util": "^2.1.1",
     "@types/node": "^14.0.13",
     "typescript": "^4.4.3"
   },
@@ -39,7 +38,6 @@
     "@types/keccak": "^3.0.1",
     "bech32": "^2.0.0",
     "bip32": "^2.0.4",
-    "eth-sig-util": "^3.0.1",
     "keccak": "^3.0.2",
     "protobufjs": "^6.11.2",
     "protocol-buffers": "^4.2.0",

--- a/packages/coin-trx/package-lock.json
+++ b/packages/coin-trx/package-lock.json
@@ -25,7 +25,8 @@
         "@babel/core": "^7.7.0",
         "@babel/plugin-proposal-class-properties": "^7.7.4",
         "@babel/preset-env": "^7.7.1",
-        "@babel/preset-typescript": "^7.7.7"
+        "@babel/preset-typescript": "^7.7.7",
+        "typescript": "^5.0.0"
       }
     },
     "node_modules/@adraffy/ens-normalize": {
@@ -4749,6 +4750,18 @@
       "version": "1.18.0",
       "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
       "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",

--- a/packages/coin-trx/package.json
+++ b/packages/coin-trx/package.json
@@ -33,7 +33,8 @@
     "@babel/core": "^7.7.0",
     "@babel/plugin-proposal-class-properties": "^7.7.4",
     "@babel/preset-env": "^7.7.1",
-    "@babel/preset-typescript": "^7.7.7"
+    "@babel/preset-typescript": "^7.7.7",
+    "typescript": "^5.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/coin-trx/tsconfig.json
+++ b/packages/coin-trx/tsconfig.json
@@ -49,7 +49,8 @@
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */
     "allowSyntheticDefaultImports": true,     /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "skipLibCheck": true
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
     // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
 


### PR DESCRIPTION
- coin-cro: 移除已無使用的 eth-sig-util 及其空殼型別套件 @types/eth-sig-util，修復 TS2688 錯誤
- coin-trx: 補上缺少的 typescript devDependency（^5.0.0），修復 npm ci lock file 不同步問題；tsconfig 加上 skipLibCheck: true

----

*Checklist:*

- README.md includes:
  - [ ] The details of signing data and transaction data, this includes parameters.
  - [ ] Official docs or white paper.
  - [ ] Website or api can query assets and broadcast transaction.

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

 
 **PR Summary by Typo**
------------

#### Overview
This PR resolves npm publishing failures for the `coin-cro` and `coin-trx` packages by removing deprecated or problematic dependencies and updating TypeScript configurations.

#### Key Changes
- Removed `eth-sig-util` and its corresponding type definitions from `coin-cro`.
- Added `typescript` dependency and enabled `skipLibCheck` in `coin-trx` to resolve compilation and publishing issues.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 15 (6.8%)     |
| Churn       | 203 (91.9%)   |
| Refactor    | 3 (1.4%)      |
| Total Changes | 221         | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>