### PR TITLE
🐛 [CW-28987] fix(btc): WITNESS_0 argument 的 nSequence 改為取自 input

### DIFF
--- a/packages/coin-btc/CHANGELOG.md
+++ b/packages/coin-btc/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 2.0.2
-- fix: WITNESS_0 argument 的 nSequence 改為取自 input，修正非 RBF 交易簽出無效簽章的問題 [CW-28987]
+- fix: WITNESS_0 argument 的 nSequence 改為取自 input，修正非 RBF 交易簽出無效簽章的問題 [CW-28987] (#1194)
 
 
 ## 2.0.1

--- a/packages/coin-btc/CHANGELOG.md
+++ b/packages/coin-btc/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.2
+- fix: WITNESS_0 argument 的 nSequence 改為取自 input，修正非 RBF 交易簽出無效簽章的問題 [CW-28987]
+
+
 ## 2.0.1
 - feat: sunset omni usdt [CW-24950] (#1026)
 

--- a/packages/coin-btc/CHANGELOG.md
+++ b/packages/coin-btc/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Changelog
 
-## 2.0.2
-- fix: WITNESS_0 argument 的 nSequence 改為取自 input，修正非 RBF 交易簽出無效簽章的問題 [CW-28987] (#1194)
-
-
 ## 2.0.1
 - feat: sunset omni usdt [CW-24950] (#1026)
 

--- a/packages/coin-btc/package-lock.json
+++ b/packages/coin-btc/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coolwallet/btc",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coolwallet/btc",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "ISC",
       "dependencies": {
         "@bitcoin-js/tiny-secp256k1-asmjs": "^2.2.3",

--- a/packages/coin-btc/package.json
+++ b/packages/coin-btc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coolwallet/btc",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Coolwallet Bitcoin sdk",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/coin-btc/src/utils/scriptUtil.ts
+++ b/packages/coin-btc/src/utils/scriptUtil.ts
@@ -25,6 +25,19 @@ const getPath = async (addressIndex: number, purpose?: number, pathType?: PathTy
   return path;
 };
 
+const DEFAULT_SEQUENCE = 0xffffffff;
+
+function assertSequencesAreAllSame(inputs: Array<Input>): void {
+  const sequences = inputs.map((input) => (input.sequence ? input.sequence : DEFAULT_SEQUENCE));
+  const [sequence] = sequences;
+  if (sequences.some((each) => each !== sequence)) {
+    throw new error.SDKError(
+      assertSequencesAreAllSame.name,
+      `All inputs must share the same sequence, got [${sequences.join(', ')}]`
+    );
+  }
+}
+
 export async function getScriptSigningActions(
   transport: Transport,
   redeemScriptType: ScriptType,
@@ -214,6 +227,14 @@ export async function getWitness0Argument(
   if (!scriptPubKey) {
     throw new error.SDKError(getWitness0Argument.name, `OutputHash Undefined`);
   }
+  if (inputs.length === 0) {
+    throw new error.SDKError(getWitness0Argument.name, `Inputs must not be empty`);
+  }
+
+  assertSequencesAreAllSame(inputs);
+
+  const sequence = inputs[0].sequence ? inputs[0].sequence : DEFAULT_SEQUENCE;
+
   const reverseVersion = Buffer.from('02000000', 'hex');
 
   const prevouts = inputs.map((input) => {
@@ -225,9 +246,7 @@ export async function getWitness0Argument(
 
   const hashPrevouts = cryptoUtil.doubleSha256(Buffer.concat(prevouts));
   const sequences = inputs.map((input) => {
-    return Buffer.concat([
-      input.sequence ? bufferUtil.toReverseUintBuffer(input.sequence, 4) : Buffer.from('ffffffff', 'hex'),
-    ]);
+    return Buffer.concat([bufferUtil.toReverseUintBuffer(sequence, 4)]);
   });
   const hashSequences = cryptoUtil.doubleSha256(Buffer.concat(sequences));
 
@@ -266,7 +285,7 @@ export async function getWitness0Argument(
     changePath = bufferUtil.toUintBuffer(0, 21); //Buffer.from('000000000000000000000000000000000000000000', 'hex');
   }
 
-  const reverseSequence = Buffer.from('fdffffff', 'hex');
+  const reverseSequence = bufferUtil.toReverseUintBuffer(sequence, 4);
 
   const reverseLockTime = Buffer.from('00000000', 'hex');
 

--- a/packages/coin-btc/src/utils/scriptUtil.ts
+++ b/packages/coin-btc/src/utils/scriptUtil.ts
@@ -25,6 +25,11 @@ const getPath = async (addressIndex: number, purpose?: number, pathType?: PathTy
   return path;
 };
 
+// 卡片是拿 script argument 裡的 nSequence 組 sighash preimage，而最終交易的同一個值是
+// transactionUtil.createUnsignedTransactions 序列化出來的 —— 兩邊不一致就會簽出無效簽章。
+// 因此這個預設值必須與 createUnsignedTransactions 相同，連 falsy 判斷都要一致：那裡同樣寫
+// `sequence ? ... : ffffffff`，所以 sequence 0 也會被正規化成 0xffffffff。只改單邊
+// （例如這裡改用 ??）會重新製造出這個修正要消滅的那種 mismatch。
 const DEFAULT_SEQUENCE = 0xffffffff;
 
 function assertSequencesAreAllSame(inputs: Array<Input>): void {
@@ -234,6 +239,7 @@ export async function getWitness0Argument(
   assertSequencesAreAllSame(inputs);
 
   const sequence = inputs[0].sequence ? inputs[0].sequence : DEFAULT_SEQUENCE;
+  const reverseSequence = bufferUtil.toReverseUintBuffer(sequence, 4);
 
   const reverseVersion = Buffer.from('02000000', 'hex');
 
@@ -245,10 +251,7 @@ export async function getWitness0Argument(
   });
 
   const hashPrevouts = cryptoUtil.doubleSha256(Buffer.concat(prevouts));
-  const sequences = inputs.map((input) => {
-    return Buffer.concat([bufferUtil.toReverseUintBuffer(sequence, 4)]);
-  });
-  const hashSequences = cryptoUtil.doubleSha256(Buffer.concat(sequences));
+  const hashSequences = cryptoUtil.doubleSha256(Buffer.concat(inputs.map(() => reverseSequence)));
 
   const zeroPadding = Buffer.from('00000000', 'hex');
 
@@ -284,8 +287,6 @@ export async function getWitness0Argument(
     changeAmount = bufferUtil.toUintBuffer(0, 8); //)Buffer.from('0000000000000000', 'hex');
     changePath = bufferUtil.toUintBuffer(0, 21); //Buffer.from('000000000000000000000000000000000000000000', 'hex');
   }
-
-  const reverseSequence = bufferUtil.toReverseUintBuffer(sequence, 4);
 
   const reverseLockTime = Buffer.from('00000000', 'hex');
 

--- a/packages/coin-btc/tests/index.spec.ts
+++ b/packages/coin-btc/tests/index.spec.ts
@@ -3,6 +3,7 @@ import { createTransport } from '@coolwallet/transport-jre-http';
 import { initialize } from '@coolwallet/testing-library';
 import BTC from '../src';
 import { ScriptType, signTxType } from '../src/config/types';
+import { getSequences, getVersion, verifySegwitV0Signatures } from './utils/verifySignature';
 
 type PromiseValue<T> = T extends Promise<infer V> ? V : never;
 type Mandatory = PromiseValue<ReturnType<typeof initialize>>;
@@ -119,6 +120,63 @@ describe('Test BTC SDK', () => {
       expect(await btcSDK.signTransaction(options)).toMatchInlineSnapshot(
         `"020000000001011ea37510dcd8d6b264556c376f335fd0e80afbad51c4e034bfb785c9a62c5cf501000000171600147c7af58931fa8a36f4c3d974e14108a60c6577fcfdffffff022b0200000000000017a9143ca1b20af95028ac60b644f6e26ca4d269dfa83c87808300000000000017a914a4df3c0070acd2e1ecf20c7457a8a5c939f98f0687024730440220750d6e6bb54733e90614571f2defbb3525256272a6c961555613ed4ec13010b302206f5c0bd56bccece37bcc1f030cf0fe3ff36dddccfeeecaddc16271fa63a88da7012103eb551a9d4044ca0aba80c03bd931456f718d5981eaf89a70e63be227fa3d044b00000000"`
       );
+    });
+  });
+
+  // 卡片是用 script argument 裡的 nSequence 自行組 BIP143 preimage 的，而最終交易的該值是 JS 端
+  // 序列化出來的。兩邊不一致時交易看起來完全正常、snapshot 也會過，只有廣播時才會被節點以
+  // script verify 失敗拒收 —— 所以這裡一律驗簽章而不只比對 snapshot。
+  describe('Sign Transfer Tx with RBF disabled (sequence=0xffffffff)', () => {
+    const PRE_VALUE = 34883;
+
+    const buildOptions = (sequence: number): signTxType => ({
+      transport,
+      appPrivateKey: props.appPrivateKey,
+      appId: props.appId,
+      scriptType: ScriptType.P2SH_P2WPKH,
+      inputs: [
+        {
+          preTxHash: 'f55c2ca6c985b7bf34e0c451adfb0ae8d05f336f376c5564b2d6d8dc1075a31e',
+          preIndex: 1,
+          preValue: String(PRE_VALUE),
+          sequence,
+          addressIndex: 0,
+        },
+      ],
+      output: { address: '37DcArQ1icSZKf7oFTosUid28kWBgsLLEz', value: '555' },
+      change: { addressIndex: 0, value: '33664' },
+      version: 2,
+    });
+
+    // 這是核心 case：訂單交易（Swap / Lombard BTC 質押）要求 version 維持韌體支援的 2，
+    // 但 sequence 用 0xffffffff 以停用 RBF。修正前 SDK 把 preimage 的 nSequence 寫死成
+    // 0xfffffffd，導致卡片簽的是另一筆交易，這個 verify 會失敗。
+    it('P2SH_P2WPKH: version=2 + sequence=0xffffffff 的簽章驗得過', async () => {
+      const signedTx = await btcSDK.signTransaction(buildOptions(0xffffffff));
+
+      expect(getVersion(signedTx)).toBe(2);
+      expect(getSequences(signedTx)).toEqual([0xffffffff]);
+      expect(verifySegwitV0Signatures(signedTx, [PRE_VALUE])).toBe(true);
+    });
+
+    it('P2SH_P2WPKH: version=2 + sequence=0xfffffffd（signal RBF）的簽章驗得過', async () => {
+      const signedTx = await btcSDK.signTransaction(buildOptions(0xfffffffd));
+
+      expect(getVersion(signedTx)).toBe(2);
+      expect(getSequences(signedTx)).toEqual([0xfffffffd]);
+      expect(verifySegwitV0Signatures(signedTx, [PRE_VALUE])).toBe(true);
+    });
+
+    // script argument 只有一格 nSequence，卡片會拿它去簽每一筆 input，
+    // 所以 sequence 不一致時必須報錯，不能簽出一筆簽章驗不過的交易。
+    it('P2SH_P2WPKH: 各 input 的 sequence 不一致時應拋錯', async () => {
+      const options = buildOptions(0xffffffff);
+      options.inputs = [
+        { ...options.inputs[0], sequence: 0xffffffff },
+        { ...options.inputs[0], preIndex: 0, sequence: 0xfffffffd },
+      ];
+
+      await expect(btcSDK.signTransaction(options)).rejects.toThrow(/same sequence/);
     });
   });
 });

--- a/packages/coin-btc/tests/index.spec.ts
+++ b/packages/coin-btc/tests/index.spec.ts
@@ -126,7 +126,7 @@ describe('Test BTC SDK', () => {
   // 卡片是用 script argument 裡的 nSequence 自行組 BIP143 preimage 的，而最終交易的該值是 JS 端
   // 序列化出來的。兩邊不一致時交易看起來完全正常、snapshot 也會過，只有廣播時才會被節點以
   // script verify 失敗拒收 —— 所以這裡一律驗簽章而不只比對 snapshot。
-  describe('Sign Transfer Tx with RBF disabled (sequence=0xffffffff)', () => {
+  describe('Sign Transfer Tx with explicit nSequence', () => {
     const PRE_VALUE = 34883;
 
     const buildOptions = (sequence: number): signTxType => ({

--- a/packages/coin-btc/tests/utils/verifySignature.ts
+++ b/packages/coin-btc/tests/utils/verifySignature.ts
@@ -1,0 +1,47 @@
+import * as bitcoin from 'bitcoinjs-lib';
+import * as tinysecp from '@bitcoin-js/tiny-secp256k1-asmjs';
+import { ECPairFactory } from 'ecpair';
+
+const ECPair = ECPairFactory(tinysecp);
+
+/**
+ * 驗證一筆已簽好的 segwit v0（P2WPKH / P2SH-P2WPKH）交易，其 witness 裡的簽章
+ * 是否真的對得上「這筆交易序列化出來的內容」。
+ *
+ * 這個檢查存在的理由：卡片是拿 script argument 裡的欄位自行組 BIP143 preimage 的，
+ * 若 SDK 送過去的 nVersion / nSequence 與 JS 端序列化進最終交易的值不一致，
+ * 卡片會對另一筆交易簽名 —— 交易長得完全正常、snapshot 也照樣過，只有節點會拒收。
+ * hashForWitnessV0 是直接讀這筆交易自己的 version 與各 input 的 sequence，
+ * 所以只有兩邊一致時才驗得過。
+ *
+ * @param rawTxHex signTransaction 回傳的完整交易 hex
+ * @param inputValues 每筆 input 被花掉的 UTXO 金額（satoshi），順序與 inputs 相同
+ */
+function verifySegwitV0Signatures(rawTxHex: string, inputValues: number[]): boolean {
+  const tx = bitcoin.Transaction.fromHex(rawTxHex);
+
+  return tx.ins.every((input, index) => {
+    const [signatureWithHashType, publicKey] = input.witness;
+    const { signature, hashType } = bitcoin.script.signature.decode(signatureWithHashType);
+    // BIP143 規定 P2WPKH / P2SH-P2WPKH 的 scriptCode 是 P2PKH 腳本（0x1976a914{pubKeyHash}88ac），
+    // 不是該 input 的 scriptPubKey（0014{pubKeyHash}）。bitcoinjs 的 Psbt 內部也是先轉成 p2pkh 再算 sighash。
+    const { output: scriptCode } = bitcoin.payments.p2pkh({ pubkey: publicKey });
+    const sigHash = tx.hashForWitnessV0(index, scriptCode!, inputValues[index], hashType);
+
+    return ECPair.fromPublicKey(publicKey).verify(sigHash, signature);
+  });
+}
+
+/**
+ * 讀出每一筆 input 實際序列化進交易的 nSequence，用來確認業務層要求的
+ * 「不 signal RBF」真的落到鏈上（BIP-125 opt-in 的條件是 sequence < 0xfffffffe）。
+ */
+function getSequences(rawTxHex: string): number[] {
+  return bitcoin.Transaction.fromHex(rawTxHex).ins.map((input) => input.sequence);
+}
+
+function getVersion(rawTxHex: string): number {
+  return bitcoin.Transaction.fromHex(rawTxHex).version;
+}
+
+export { verifySegwitV0Signatures, getSequences, getVersion };


### PR DESCRIPTION
## Overview

`getWitness0Argument` 在組給卡片的 script argument 時，把 BIP143 preimage 的 **nSequence 寫死成 `0xfffffffd`**。卡片是拿這個 argument 自行組 preimage 來簽名的，而最終交易的該值是 JS 端 `createUnsignedTransactions` 序列化出來的 —— 兩邊不一致時，卡片等於對「另一筆交易」簽名。

結果：**交易格式完全正常、snapshot 測試照樣過，只有廣播時才會被節點以 script verify 失敗拒收。**

## Key Changes

- `reverseSequence` 改為取自 `inputs[0].sequence`，預設 `0xffffffff` 與 `createUnsignedTransactions` 對缺省值的處理一致（原本兩邊預設值不同，呼叫端省略 `sequence` 時也會不一致）。
- 新增 `assertSequencesAreAllSame`：script argument 只有**一格** nSequence，卡片會拿它去簽**每一筆** input，因此所有 input 的 sequence 必須相同。不同時直接拋錯，而不是默默簽出一筆簽章驗不過的交易。這個限制過去只是隱含假設，從未被寫下來。
- `getWitness1Argument`（Taproot）**刻意不比照處理**：BIP341 的 SIGHASH_ALL preimage 只有聚合的 `sha_sequences`、沒有單筆 nSequence 欄位，混用 sequence 在那條路徑上本來就合法，不該擋。

## Verification
- [x] `packages/coin-btc/tests/index.spec.ts` 新增 3 個 `P2SH_P2WPKH` case：`sequence = 0xffffffff`、`0xfffffffd`、各 input 不一致要拋錯。全數通過。
- [x] 既有的 `Sign Transfer Tx` snapshot 測試不受影響（`0xfffffffd` 為原本行為，byte-identical）。
- [x] `tsc --noEmit` 0 error；`eslint` 0 error。

### 關於新增的 `tests/utils/verifySignature.ts`

**純比對 snapshot 抓不到這個 bug** —— 壞交易長得完全正常，只有節點會拒收。所以新增的 case 不只比對交易內容，而是把簽好的交易解出來，用 `hashForWitnessV0`（讀交易**自己的** version 與各 input sequence）重算 sighash 再驗簽章，等同在測試裡重現節點驗證時組 preimage 那一步。

這個 helper 本身已用兩個基準驗證過：

1. 對既有 `P2SH_P2WPKH` snapshot（真卡簽出、已知有效的交易）回 `true`。
2. 對手刻的壞交易（preimage 用 `fdffffff`、序列化用 `ffffffff`）回 `false` —— 確認它真的抓得到這個 bug，不是空轉。

## Note

`version` 欄位在同兩個 argument builder 內也有相同形狀的寫死（`reverseVersion = 02000000`）。對本 PR 的情境而言 version 恆為 2、剛好對上，但呼叫端若省略 `version`（型別上是選填，`createUnsignedTransactions` 預設為 1）同樣會簽出無效簽章。該修正**刻意拆到另一個 PR**，以維持本 PR 的範圍單一。

 
 **PR Summary by Typo**
------------

#### Overview
This pull request fixes an issue in the Bitcoin SDK where the `nSequence` argument used in WITNESS_0 script generation was hardcoded instead of being dynamically derived from the transaction inputs. This mismatch caused invalid signatures during transaction broadcasting.

#### Key Changes
- Updated package version to `2.0.2` in `package.json` and `package-lock.json`.
- Modified `getWitness0Argument` in `scriptUtil.ts` to utilize the sequence value from inputs and enforce that all inputs share the same sequence via a new validation helper.
- Added signature verification utilities and unit tests to ensure generated signatures correctly match transaction sequences.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 132 (92.3%)   |
| Churn       | 7 (4.9%)      |
| Refactor    | 4 (2.8%)      |
| Total Changes | 143         | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>